### PR TITLE
Removed unused glob patterm

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -39,7 +39,6 @@ go_test(
         "sense_test.go",
         "tar_test.go",
     ],
-    data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = ["@com_github_google_go_cmp//cmp:go_default_library"],
 )


### PR DESCRIPTION
This testdata dir was deleted in a previous commit.
Having it in prevent using this repo with bazel '--incomppatible_disallow_empty_glob' flag.